### PR TITLE
Simplify target package management

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,22 @@ Syntax Theme: [base16-tomorrow-dark](https://github.com/atom/base16-tomorrow-dar
 Command                                  | Description
 -----------------------------------------|---------------------------------------
 `atom-hot-package-loader:select-package` | Select target package
+`atom-hot-package-loader:detect-package` | Try guessing target package
 `atom-hot-package-loader:reload`         | Reload targeted package
 `atom-hot-package-loader:watch`          | Start targeted package's file watching
 `atom-hot-package-loader:unwatch`        | Stop watching
 
+## Settings
+
+Setting              | Description
+---------------------|-----------------------------------------------------------------------
+`autoWatchTarget`    | Start watching the targeted package right after it has been selected
+`detectTargetOnStar` | Try guessing target package automatically when activating this package
+`outputLog`          | Print debug info to console
+
 ## Usage
 
-Select target package by using `atom-hot-package-loader:select-package`.
+Select target package by using `atom-hot-package-loader:select-package`. Alternatively you can use `atom-hot-package-loader:detect-package` command which will try to guess target package based on paths of active text editor and project's root directories.
 
 [![https://gyazo.com/900544de8bbf23d4a269288772ffb292](https://i.gyazo.com/900544de8bbf23d4a269288772ffb292.png)](https://gyazo.com/900544de8bbf23d4a269288772ffb292)
 

--- a/lib/atom-hot-package-loader.js
+++ b/lib/atom-hot-package-loader.js
@@ -7,6 +7,10 @@ import reloadPackage from './reload-package';
 import PackageWatcher from './package-wacher';
 import StatusBarManager from './status-bar-manager';
 
+function getConfig(name) {
+  return atom.config.get(`atom-hot-package-loader.${name}`);
+}
+
 export default class AtomHotPackageLoader {
   constructor() {
     this.subscriptions = null;
@@ -20,31 +24,14 @@ export default class AtomHotPackageLoader {
     this.packageWatcher = new PackageWatcher();
     this.packagesListView = new PackagesListView();
     this.packagesListView.emitter.on('did-confirm', (packageName) => {
-      this.targetPackageName = packageName;
-      this.statusBarManager.update('target', this.targetPackageName);
+      this.setTargetPackage(packageName);
     });
     this.statusBarManager = new StatusBarManager();
 
     this.subscriptions.add(atom.commands.add('atom-workspace', {
-      'atom-hot-package-loader:reload': () => {
-        if (this.targetPackageName) {
-          reloadPackage(this.targetPackageName, true)
-        } else {
-          this.showNotificationForSelectPackage();
-        }
-      },
-      'atom-hot-package-loader:watch': () => {
-        if (this.targetPackageName) {
-          this.statusBarManager.update('wathing', this.targetPackageName);
-          this.packageWatcher.watch(this.targetPackageName);
-        } else {
-          this.showNotificationForSelectPackage();
-        }
-      },
-      'atom-hot-package-loader:unwatch': () => {
-        this.packageWatcher.unwatch();
-        this.statusBarManager.update('target', this.targetPackageName);
-      },
+      'atom-hot-package-loader:reload': this.reload.bind(this),
+      'atom-hot-package-loader:watch': this.watch.bind(this),
+      'atom-hot-package-loader:unwatch': this.unwatch.bind(this),
       'atom-hot-package-loader:select-package': () => {
         this.packagesListView.toggle();
       },
@@ -54,6 +41,33 @@ export default class AtomHotPackageLoader {
   consumeStatusBar(statusBar) {
     this.statusBarManager.initialize(statusBar);
     this.statusBarManager.attach();
+  }
+
+  setTargetPackage(packageName) {
+    this.targetPackageName = packageName;
+    this.statusBarManager.update('target', this.targetPackageName);
+  }
+
+  reload() {
+    if (this.targetPackageName) {
+      reloadPackage(this.targetPackageName);
+    } else {
+      this.showNotificationForSelectPackage();
+    }
+  }
+
+  watch() {
+    if (this.targetPackageName) {
+      this.statusBarManager.update('watching', this.targetPackageName);
+      this.packageWatcher.watch(this.targetPackageName);
+    } else {
+      this.showNotificationForSelectPackage();
+    }
+  }
+
+  unwatch() {
+    this.packageWatcher.unwatch();
+    this.statusBarManager.update('target', this.targetPackageName);
   }
 
   showNotificationForSelectPackage() {

--- a/lib/atom-hot-package-loader.js
+++ b/lib/atom-hot-package-loader.js
@@ -46,6 +46,10 @@ export default class AtomHotPackageLoader {
         this.packagesListView.toggle();
       },
     }));
+
+    if (getConfig('detectTargetOnStart')) {
+      this.detectPackage();
+    }
   }
 
   consumeStatusBar(statusBar) {

--- a/lib/atom-hot-package-loader.js
+++ b/lib/atom-hot-package-loader.js
@@ -45,6 +45,8 @@ export default class AtomHotPackageLoader {
 
   setTargetPackage(packageName) {
     this.targetPackageName = packageName;
+
+    this.unwatch();
     this.statusBarManager.update('target', this.targetPackageName);
   }
 
@@ -75,6 +77,8 @@ export default class AtomHotPackageLoader {
   }
 
   deactivate() {
+    this.unwatch();
+
     this.subscriptions.dispose();
     if (this.statusBarManager) {
       this.statusBarManager.detach();

--- a/lib/atom-hot-package-loader.js
+++ b/lib/atom-hot-package-loader.js
@@ -50,6 +50,10 @@ export default class AtomHotPackageLoader {
 
     this.unwatch();
     this.statusBarManager.update('target', this.targetPackageName);
+
+    if (getConfig('autoWatchTarget')) {
+      this.watch();
+    }
   }
 
   reload() {

--- a/lib/atom-hot-package-loader.js
+++ b/lib/atom-hot-package-loader.js
@@ -44,6 +44,8 @@ export default class AtomHotPackageLoader {
   }
 
   setTargetPackage(packageName) {
+    if (packageName === this.targetPackageName) return;
+
     this.targetPackageName = packageName;
 
     this.unwatch();

--- a/lib/atom-hot-package-loader.js
+++ b/lib/atom-hot-package-loader.js
@@ -1,6 +1,7 @@
 "use babel";
 
 import { CompositeDisposable, Disposable } from 'atom';
+import fs from 'fs';
 import path from 'path';
 import PackagesListView from './packages-list-view';
 import reloadPackage from './reload-package';
@@ -9,6 +10,14 @@ import StatusBarManager from './status-bar-manager';
 
 function getConfig(name) {
   return atom.config.get(`atom-hot-package-loader.${name}`);
+}
+
+function findPackageAtPath(packPath) {
+  packPath = fs.realpathSync(packPath);
+  return atom.packages.getLoadedPackages().find(({path}) => {
+    path = fs.realpathSync(path);
+    return packPath.startsWith(path);
+  });
 }
 
 export default class AtomHotPackageLoader {
@@ -32,6 +41,7 @@ export default class AtomHotPackageLoader {
       'atom-hot-package-loader:reload': this.reload.bind(this),
       'atom-hot-package-loader:watch': this.watch.bind(this),
       'atom-hot-package-loader:unwatch': this.unwatch.bind(this),
+      'atom-hot-package-loader:detect-package': this.detectPackage.bind(this),
       'atom-hot-package-loader:select-package': () => {
         this.packagesListView.toggle();
       },
@@ -76,6 +86,26 @@ export default class AtomHotPackageLoader {
   unwatch() {
     this.packageWatcher.unwatch();
     this.statusBarManager.update('target', this.targetPackageName);
+  }
+
+  detectPackage() {
+    let pack = null;
+
+    // Try deducing package based on active text editor path
+    const editor = atom.workspace.getActiveTextEditor();
+    if(editor && editor.getPath()) {
+      const editorPath = editor.getPath();
+      pack = findPackageAtPath(editorPath);
+    }
+
+    if (!pack) {
+      // Try deducing package for any of project root folders
+      atom.project.getPaths().find((path) => pack = findPackageAtPath(path));
+    }
+
+    if (pack) {
+      this.setTargetPackage(pack.name);
+    }
   }
 
   showNotificationForSelectPackage() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,14 @@ import AtomHotPackageLoader from './atom-hot-package-loader';
 let atomHotPackageLoader = null;
 
 export const config = {
+  autoWatchTarget: {
+    order: 1,
+    type: 'boolean',
+    default: false,
+    description: 'Start watching the targeted package right after it has been selected',
+  },
   outputLog: {
+    order: 2,
     type: 'boolean',
     default: false,
     description: 'Output log',

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,14 @@ export const config = {
     default: false,
     description: 'Start watching the targeted package right after it has been selected',
   },
-  outputLog: {
+  detectTargetOnStart: {
     order: 2,
+    type: 'boolean',
+    default: false,
+    description: 'Detect target package automatically when activating this package',
+  },
+  outputLog: {
+    order: 3,
     type: 'boolean',
     default: false,
     description: 'Output log',

--- a/menus/atom-hot-package-loader.cson
+++ b/menus/atom-hot-package-loader.cson
@@ -2,8 +2,19 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'atom-hot-package-loader'
+      'label': 'Hot Package Loader'
       'submenu': [
+        {
+          'label': 'Select Package'
+          'command': 'atom-hot-package-loader:select-package'
+        },
+        {
+          'label': 'Detect Package'
+          'command': 'atom-hot-package-loader:detect-package'
+        },
+        {
+          'type': 'separator'
+        },
         {
           'label': 'Reload'
           'command': 'atom-hot-package-loader:reload'
@@ -16,10 +27,6 @@
           'label': 'Unwatch'
           'command': 'atom-hot-package-loader:unwatch'
         },
-        {
-          'label': 'SelectPackage'
-          'command': 'atom-hot-package-loader:select-package'
-        }
       ]
     ]
   }


### PR DESCRIPTION
Improvements:
- Add `autoWatchTarget` setting to start watching target package upon selecting it.
- Add command `atom-hot-package-loader:detect-package` to try guessing package based on active text editor and project paths.
  
  _Do you have any advices on how to improve detection logic?_
- Add `detectTargetOnStart` setting to call `detect-package` command upon activation.
  _Not showing any notifications currently if nothing detected. Maybe show them only when in devMode?_
- Refine menu a bit.

Fixes:
- Unwatch target package when switching to another package.
  
  _Welp, not sure if this was a bug or a feature, though._
- Unwatch target upon deactivation.
