### PR TITLE
Ignore redundant paths

### DIFF
--- a/lib/package-wacher.js
+++ b/lib/package-wacher.js
@@ -17,16 +17,20 @@ export default class PackageWacher {
 
     const packagePath = atom.packages.resolvePackagePath(packageName);
     const ignoredMatchers = await this.makeIgnoredMatchers(packagePath);
-    this.watcher = chokidar.watch(packagePath, {
-      persistent: true,
-      ignoreInitial: true,
-      ignored: ignoredMatchers,
-    });
-    this.watcher.on('change', (filename) => {
-      const dir = path.dirname(filename);
-      const reloadGrammars = dir === path.join(packagePath, 'grammars');
-      reloadPackage(packageName, reloadGrammars);
-    });
+    this.watcher = chokidar
+      .watch(packagePath, {
+        persistent: true,
+        ignoreInitial: true,
+        ignored: ignoredMatchers,
+      })
+      .on('change', (filename) => {
+        const dir = path.dirname(filename);
+        const reloadGrammars = dir === path.join(packagePath, 'grammars');
+        reloadPackage(packageName, reloadGrammars);
+      })
+      .on('error', (error) => {
+        log(`Error watching package \'${packageName}\': `, error);
+      });
 
     atom.notifications.addInfo(`Start watching \`${packageName}\`.`);
   }

--- a/lib/package-wacher.js
+++ b/lib/package-wacher.js
@@ -3,22 +3,24 @@
 import reloadPackage from './reload-package';
 import chokidar from 'chokidar';
 import path from 'path';
+import { log, getConfig, getRepositoryForDirectory } from './utils';
 
 export default class PackageWacher {
   constructor() {
     this.watcher = null;
   }
 
-  watch(packageName) {
+  async watch(packageName) {
     if (this.watcher) {
       this.unwatch();
     }
 
     const packagePath = atom.packages.resolvePackagePath(packageName);
-
+    const ignoredMatchers = await this.makeIgnoredMatchers(packagePath);
     this.watcher = chokidar.watch(packagePath, {
       persistent: true,
       ignoreInitial: true,
+      ignored: ignoredMatchers,
     });
     this.watcher.on('change', (filename) => {
       const dir = path.dirname(filename);
@@ -35,5 +37,22 @@ export default class PackageWacher {
       atom.notifications.addInfo('Stop watching.');
       this.watcher = null;
     }
+  }
+
+  async makeIgnoredMatchers(packPath) {
+    const packageRepo = await getRepositoryForDirectory(packPath);
+    const resourceExtNames = [...Object.keys(require.extensions), '.json', '.cson', '.css', '.less'];
+    function isPathIgnored(testPath, stat) {
+      if (packageRepo && packageRepo.isPathIgnored(testPath)) return true;
+
+      if (stat && stat.isFile()) {
+        const extName = path.extname(testPath);
+        return resourceExtNames.indexOf(extName) < 0;
+      }
+
+      return false;
+    }
+
+    return [...getConfig('ignoredNames', 'core'), isPathIgnored.bind(this)];
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,15 @@
 'use babel';
 
+import { Directory } from 'atom';
 import fs from 'fs';
 
 export function getConfig(name, packName = 'atom-hot-package-loader') {
   return atom.config.get(`${packName}.${name}`);
+}
+
+export function getRepositoryForDirectory(dirPath) {
+  const dir = new Directory(dirPath);
+  return atom.project.repositoryForDirectory(dir);
 }
 
 export function findPackageAtPath(packPath) {


### PR DESCRIPTION
When watching package folder, ignore paths:
1. Specified in `core.ignoredNames` glob patterns
2. Ignored by repo provider
3. Not matching possible resource file extensions

Fixes:
- `ENOSPC` error when watching too much files (e.g. because of node_modules folder).
