### PR TITLE
Delay package reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ Command                                  | Description
 
 ## Settings
 
-Setting              | Description
----------------------|-----------------------------------------------------------------------
-`autoWatchTarget`    | Start watching the targeted package right after it has been selected
-`detectTargetOnStar` | Try guessing target package automatically when activating this package
-`outputLog`          | Print debug info to console
+Setting                    | Description
+---------------------------|-----------------------------------------------------------------------
+`autoWatchTarget`          | Start watching the targeted package right after it has been selected
+`detectTargetOnStar`       | Try guessing target package automatically when activating this package
+`watchedTargetReloadDelay` | Delay before reloading watched target package
+`outputLog`                | Print debug info to console
 
 ## Usage
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,14 @@ export const config = {
     default: false,
     description: 'Detect target package automatically when activating this package',
   },
-  outputLog: {
+  watchedTargetReloadDelay: {
     order: 3,
+    type: 'integer',
+    default: 100,
+    description: 'Delay (ms) before reloading watched target package. Unwatch and watch target package again in order for this setting to take effect.',
+  },
+  outputLog: {
+    order: 4,
     type: 'boolean',
     default: false,
     description: 'Output log',

--- a/lib/package-wacher.js
+++ b/lib/package-wacher.js
@@ -3,6 +3,7 @@
 import reloadPackage from './reload-package';
 import chokidar from 'chokidar';
 import path from 'path';
+import { getConfig } from './utils';
 
 export default class PackageWacher {
   constructor() {
@@ -19,6 +20,9 @@ export default class PackageWacher {
     this.watcher = chokidar.watch(packagePath, {
       persistent: true,
       ignoreInitial: true,
+      awaitWriteFinish: {
+        stabilityThreshold: getConfig('watchedTargetReloadDelay'),
+      },
     });
     this.watcher.on('change', (filename) => {
       const dir = path.dirname(filename);


### PR DESCRIPTION
Add setting `watchedTargetReloadDelay` to delay package reloading and filter out intermidiate events.

Updating setting value currently requires unwatching target and watching it again.
